### PR TITLE
Cnysten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/06/07 10:56:18 by cchen             #+#    #+#              #
-#    Updated: 2022/06/09 16:25:56 by cchen            ###   ########.fr        #
+#    Updated: 2022/06/26 01:07:04 by carlnysten       ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -42,6 +42,10 @@ $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 
 $(LIBFT):
 	$(MAKE) -C $(LIB_DIR)
+
+debug: CFLAGS += -g
+debug: $(LIBFT) $(OBJ_DIR) $(OBJS)
+	@$(CC) $(CFLAGS) $(OBJS) $(LIB_OBJS) $(LINK) -o $(NAME)
 
 clean:
 	@rm -rf $(OBJ_DIR)

--- a/includes/flow_node.h
+++ b/includes/flow_node.h
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 14:47:39 by cchen             #+#    #+#             */
-/*   Updated: 2022/06/09 16:06:29 by cchen            ###   ########.fr       */
+/*   Updated: 2022/06/26 01:11:00 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,8 @@ typedef struct s_flow_node
 {
 	char	*alias;
 	t_vec	edges;
+	int		x;
+	int		y;
 }				t_flow_node;
 
 int			node_make(t_flow_node *node, char *alias);


### PR DESCRIPTION
Minor pull request adding a debug rule to the makefile and x and y coordinate members to the `flow_node` struct. The debug rule for the makefile simply adds the `-g` to the compiler flags when `make debug` is run. The coordinate members are necessary to store the x and y coordinates of the parsed input.