### PR TITLE
Quiet flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/06/07 10:56:18 by cchen             #+#    #+#              #
-#    Updated: 2022/08/01 16:55:51 by cchen            ###   ########.fr        #
+#    Updated: 2022/08/02 14:40:51 by carlnysten       ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,6 +33,8 @@ SRCS += $(SRC_DIR)/bfs.c
 SRCS += $(SRC_DIR)/bfs_search.c
 SRCS += $(SRC_DIR)/path.c
 SRCS += $(SRC_DIR)/pathset.c
+SRCS += $(SRC_DIR)/print.c
+SRCS += $(SRC_DIR)/print_utils.c
 SRCS += $(SRC_DIR)/solve.c
 
 OBJ_DIR := ./obj

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/06/07 10:56:18 by cchen             #+#    #+#              #
-#    Updated: 2022/08/02 17:37:07 by carlnysten       ###   ########.fr        #
+#    Updated: 2022/08/02 20:28:32 by carlnysten       ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -37,6 +37,7 @@ SRCS += $(SRC_DIR)/print.c
 SRCS += $(SRC_DIR)/print_utils.c
 SRCS += $(SRC_DIR)/pathset_solve_tools.c
 SRCS += $(SRC_DIR)/solve.c
+SRCS += $(SRC_DIR)/options.c
 
 OBJ_DIR := ./obj
 OBJS := $(SRCS:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)

--- a/includes/lem_in.h
+++ b/includes/lem_in.h
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 14:04:58 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 09:34:13 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 20:18:30 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@
 # include "pathset.h"
 # include "printer.h"
 # include "solve.h"
+# include "options.h"
 
 # define OK 1
 # define TRUE 1

--- a/includes/options.h
+++ b/includes/options.h
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   options.h                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/08/02 20:10:11 by carlnysten        #+#    #+#             */
+/*   Updated: 2022/08/02 20:27:52 by carlnysten       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef OPTIONS_H
+# define OPTIONS_H
+
+# define MSG_USAGE "Usage: ./lem-in\n  -q, quiet mode\n  -v, verbose mode"
+
+typedef struct s_options
+{
+	uint8_t	quiet;
+	uint8_t	verbose;
+}	t_options;
+
+int	options_init(t_options *options, int argc, char **argv);
+
+#endif

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/23 08:58:46 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/01 13:36:37 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/02 20:42:21 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 
 # include "vec.h"
 # include "hashmap.h"
+# include "options.h"
 
 typedef enum e_stage
 {
@@ -41,7 +42,7 @@ typedef struct s_parser
 
 typedef int	(*t_parse_func)(t_parser *, t_flow_network *);
 
-int	parse_input(t_flow_network *network);
+int	parse_input(t_flow_network *network, t_options *options);
 int	parse_ant_number(t_parser *parser, t_flow_network *network);
 int	parse_room(t_parser *parser, t_flow_network *network);
 int	parse_link(t_parser *parser, t_flow_network *network);

--- a/includes/printer.h
+++ b/includes/printer.h
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 23:03:06 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 10:17:11 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 13:30:40 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ typedef struct s_printer
 	t_vec	move;
 	int		ant_number;
 	size_t	start_line;
+	size_t	dash_id;
 }	t_printer;
 
 int	print_solution(t_flow_network *network, t_pathset *pathset);

--- a/includes/printer.h
+++ b/includes/printer.h
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 23:03:06 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 14:32:56 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:40:03 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ typedef struct s_printer
 	size_t	dash_id;
 }	t_printer;
 
-int		print_solution(t_flow_network *network, t_pathset *pathset);
+int		print_solution(t_pathset *pathset);
 int		has_ants_to_send(t_pathset *pathset);
 void	put_line(void *ptr);
 void	update_move_prefix(t_printer *printer);

--- a/includes/printer.h
+++ b/includes/printer.h
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 23:03:06 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 13:30:40 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:32:56 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,9 @@ typedef struct s_printer
 	size_t	dash_id;
 }	t_printer;
 
-int	print_solution(t_flow_network *network, t_pathset *pathset);
-int	has_ants_to_send(t_pathset *pathset);
+int		print_solution(t_flow_network *network, t_pathset *pathset);
+int		has_ants_to_send(t_pathset *pathset);
+void	put_line(void *ptr);
+void	update_move_prefix(t_printer *printer);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,11 +6,12 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 11:05:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 13:56:21 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/02 14:39:45 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
+#include "printer.h"
 
 int	main(void)
 {
@@ -23,6 +24,11 @@ int	main(void)
 		return (network_free(&network), ERROR);
 	if (solve(&network, &pathset) == ERROR)
 		return (network_free(&network), ERROR);
+	if (print_solution(&pathset) == ERROR)
+	{
+		network_free(&network);
+		return (pathset_free(&pathset), ERROR);
+	}
 	network_free(&network);
 	pathset_free(&pathset);
 	//system("leaks lem-in");

--- a/src/main.c
+++ b/src/main.c
@@ -6,11 +6,10 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 11:05:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 20:57:38 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 21:02:52 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "ft_printf.h"
 #include "lem_in.h"
 
 int	main(int argc, char **argv)

--- a/src/main.c
+++ b/src/main.c
@@ -6,10 +6,11 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 11:05:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 20:30:21 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 20:57:38 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "ft_printf.h"
 #include "lem_in.h"
 
 int	main(int argc, char **argv)
@@ -26,7 +27,9 @@ int	main(int argc, char **argv)
 		return (network_free(&network), ERROR);
 	if (solve(&network, &pathset) == ERROR)
 		return (network_free(&network), ERROR);
-	if (print_solution(&pathset) == ERROR)
+	if (options.quiet)
+		ft_printf("Solved with %i steps.\n", (int) pathset.steps);
+	else if (print_solution(&pathset) == ERROR)
 	{
 		network_free(&network);
 		return (pathset_free(&pathset), ERROR);

--- a/src/main.c
+++ b/src/main.c
@@ -6,18 +6,20 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 11:05:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 17:36:44 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 20:25:12 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
-#include "printer.h"
 
-int	main(void)
+int	main(int argc, char **argv)
 {
+	t_options		options;
 	t_flow_network	network;
 	t_pathset		pathset;
 
+	if (options_init(&options, argc, argv) == ERROR)
+		return (ft_putendl(MSG_USAGE), OK);
 	if (network_init(&network) == ERROR)
 		return (error(MSG_ERR_NETWORK_INIT));
 	if (parse_input(&network) == ERROR)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 11:05:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/02 20:25:12 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 20:30:21 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ int	main(int argc, char **argv)
 		return (ft_putendl(MSG_USAGE), OK);
 	if (network_init(&network) == ERROR)
 		return (error(MSG_ERR_NETWORK_INIT));
-	if (parse_input(&network) == ERROR)
+	if (parse_input(&network, &options) == ERROR)
 		return (network_free(&network), ERROR);
 	if (solve(&network, &pathset) == ERROR)
 		return (network_free(&network), ERROR);

--- a/src/options.c
+++ b/src/options.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   options.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/08/02 20:25:23 by carlnysten        #+#    #+#             */
+/*   Updated: 2022/08/02 20:26:48 by carlnysten       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "lem_in.h"
+
+int	options_init(t_options *options, int argc, char **argv)
+{
+	int	i;
+
+	*options = (t_options){FALSE};
+	if (argc == 1)
+		return (OK);
+	i = 1;
+	while (i < argc)
+	{
+		if (!ft_strcmp(argv[i], "-q"))
+			options->quiet = TRUE;
+		else if (!ft_strcmp(argv[i], "-v"))
+			options->verbose = TRUE;
+		else
+			return (ERROR);
+		i++;
+	}
+	return (OK);
+}

--- a/src/parse.c
+++ b/src/parse.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/22 23:28:30 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 21:00:05 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 21:13:24 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ int	parse_input(t_flow_network *network, t_options *options)
 		}
 		else if (g_parser_jumptable[parser.stage](&parser, network) == ERROR)
 			return (parser_free(&parser), ERROR);
-		if (!options->quiet)
+		if (!options->quiet || (parser.line[0] == '#' && parser.line[1] != '#'))
 			ft_putendl(parser.line);
 		ft_strdel(&parser.line);
 	}

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parse_input.c                                      :+:      :+:    :+:   */
+/*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/22 23:28:30 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 13:55:43 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/02 20:41:44 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,13 @@ static const t_parse_func	g_parser_jumptable[3] = {
 	parse_room,
 	parse_link
 };
+
+static void	parser_free(t_parser *parser)
+{
+	if (parser->line)
+		ft_strdel(&parser->line);
+	hashmap_free(&parser->hmap);
+}
 
 static int	check_for_modification(t_parser *parser)
 {
@@ -29,7 +36,7 @@ static int	check_for_modification(t_parser *parser)
 	return (OK);
 }
 
-int	parse_input(t_flow_network *network)
+int	parse_input(t_flow_network *network, t_options *options)
 {
 	t_parser	parser;
 
@@ -37,22 +44,23 @@ int	parse_input(t_flow_network *network)
 	while (1)
 	{
 		if (get_next_line(0, &parser.line) == ERROR)
-			return (error(MSG_ERROR_GNL));
+			return (parser_free(&parser), error(MSG_ERROR_GNL));
 		if (!parser.line)
 			break ;
 		if (parser.line[0] == '#')
 		{
 			if (check_for_modification(&parser) == ERROR)
-				return (ft_strdel(&parser.line), ERROR);
+				return (parser_free(&parser), ERROR);
 		}
 		else if (g_parser_jumptable[parser.stage](&parser, network) == ERROR)
 			return (ft_strdel(&parser.line), ERROR);
-		ft_putendl(parser.line);
+		if (!options->quiet)
+			ft_putendl(parser.line);
 		ft_strdel(&parser.line);
 	}
-	hashmap_free(&parser.hmap);
 	if (parser.stage != LINKS)
-		return (error(MSG_ERROR_INV_FILE));
-	ft_putchar('\n');
-	return (OK);
+		return (parser_free(&parser), error(MSG_ERROR_INV_FILE));
+	if (!options->quiet)
+		ft_putchar('\n');
+	return (parser_free(&parser), OK);
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/22 23:28:30 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 20:41:44 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 21:00:05 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ int	parse_input(t_flow_network *network, t_options *options)
 				return (parser_free(&parser), ERROR);
 		}
 		else if (g_parser_jumptable[parser.stage](&parser, network) == ERROR)
-			return (ft_strdel(&parser.line), ERROR);
+			return (parser_free(&parser), ERROR);
 		if (!options->quiet)
 			ft_putendl(parser.line);
 		ft_strdel(&parser.line);

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 18:47:54 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 10:12:12 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 12:15:44 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,6 @@ static void	update_move_prefix(t_printer *printer)
 	number_string = ft_itoa(printer->ant_number);
 	if (!number_string)
 		return ;
-	ft_printf("ns adr %p\n", number_string);
 	vec_append_str(&printer->move, number_string);
 	ft_strdel(&number_string);
 	vec_append_strn(&printer->move, "-", 1);
@@ -78,13 +77,14 @@ static void	send_ant(t_printer *printer, t_flow_network *network)
 
 	update_move_prefix(printer);
 	dash_id = printer->move.len;
-	i = 1;
-	while (i < printer->path->nodes.len)
+	i = 0;
+	while (i < printer->path->nodes.len - 1)
 	{
 		printer->move.len = dash_id;
-		node_id = *(size_t *)vec_get(&printer->path->nodes, i);
+		node_id = *(size_t *)vec_get(&printer->path->nodes,
+				printer->path->nodes.len - i - 2);
 		vec_append_str(&printer->move, network_get(network, node_id)->alias);
-		line = vec_get(&printer->lines, printer->start_line + i - 1);
+		line = vec_get(&printer->lines, printer->start_line + i);
 		vec_append_str(line, printer->move.memory);
 		vec_append_strn(line, " ", 1);
 		i++;

--- a/src/print.c
+++ b/src/print.c
@@ -6,12 +6,11 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 18:47:54 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 12:15:44 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 13:22:32 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
-#include "vec.h"
 
 static int	printer_init(t_printer *printer, t_pathset *pathset)
 {
@@ -68,12 +67,12 @@ static void	update_move_prefix(t_printer *printer)
 	vec_append_strn(&printer->move, "-", 1);
 }
 
-static void	send_ant(t_printer *printer, t_flow_network *network)
+static void	send_ant(t_printer *printer)
 {
-	size_t	i;
-	size_t	node_id;
-	size_t	dash_id;
-	t_vec	*line;
+	t_flow_node	*node;
+	t_vec		*line;
+	size_t		i;
+	size_t		dash_id;
 
 	update_move_prefix(printer);
 	dash_id = printer->move.len;
@@ -81,9 +80,8 @@ static void	send_ant(t_printer *printer, t_flow_network *network)
 	while (i < printer->path->nodes.len - 1)
 	{
 		printer->move.len = dash_id;
-		node_id = *(size_t *)vec_get(&printer->path->nodes,
-				printer->path->nodes.len - i - 2);
-		vec_append_str(&printer->move, network_get(network, node_id)->alias);
+		node = vec_get(&printer->path->nodes, printer->path->nodes.len - i - 2);
+		vec_append_str(&printer->move, node->alias);
 		line = vec_get(&printer->lines, printer->start_line + i);
 		vec_append_str(line, printer->move.memory);
 		vec_append_strn(line, " ", 1);
@@ -91,8 +89,7 @@ static void	send_ant(t_printer *printer, t_flow_network *network)
 	}
 }
 
-static void	send_ant_wave(t_printer *printer, t_pathset *pathset,
-	t_flow_network *network)
+static void	send_ant_wave(t_printer *printer, t_pathset *pathset)
 {
 	size_t	i;
 
@@ -104,7 +101,7 @@ static void	send_ant_wave(t_printer *printer, t_pathset *pathset,
 		{
 			printer->path->ants--;
 			printer->ant_number++;
-			send_ant(printer, network);
+			send_ant(printer);
 		}
 		i++;
 	}
@@ -125,11 +122,12 @@ int	print_solution(t_flow_network *network, t_pathset *pathset)
 {
 	t_printer	printer;
 
+	(void) network;
 	if (printer_init(&printer, pathset) == ERROR)
 		return (printer_free(&printer), ERROR);
 	while (has_ants_to_send(pathset))
 	{
-		send_ant_wave(&printer, pathset, network);
+		send_ant_wave(&printer, pathset);
 	}
 	vec_iter(&printer.lines, put_line);
 	return (printer_free(&printer), OK);

--- a/src/print.c
+++ b/src/print.c
@@ -111,15 +111,6 @@ static void	send_ant_wave(t_printer *printer, t_pathset *pathset,
 	printer->start_line++;
 }
 
-static int	has_ants_to_send(t_pathset *pathset)
-{
-	static t_path	*shortest_path;
-
-	if (!shortest_path)
-		shortest_path = vec_get(&pathset->paths, 0);
-	return (shortest_path->ants > 0);
-}
-
 static void	put_line(void *line)
 {
 	char	*str;

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 18:47:54 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 13:22:32 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:27:46 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,17 +54,15 @@ static void	printer_free(t_printer *printer)
 static void	update_move_prefix(t_printer *printer)
 {
 	char	*number_string;
-	char	*move;
 
 	printer->move.len = 1;
-	move = printer->move.memory;
-	move[1] = '\0';
 	number_string = ft_itoa(printer->ant_number);
 	if (!number_string)
 		return ;
 	vec_append_str(&printer->move, number_string);
 	ft_strdel(&number_string);
 	vec_append_strn(&printer->move, "-", 1);
+	printer->dash_id = printer->move.len;
 }
 
 static void	send_ant(t_printer *printer)
@@ -72,18 +70,16 @@ static void	send_ant(t_printer *printer)
 	t_flow_node	*node;
 	t_vec		*line;
 	size_t		i;
-	size_t		dash_id;
 
 	update_move_prefix(printer);
-	dash_id = printer->move.len;
 	i = 0;
 	while (i < printer->path->nodes.len - 1)
 	{
-		printer->move.len = dash_id;
+		printer->move.len = printer->dash_id;
 		node = vec_get(&printer->path->nodes, printer->path->nodes.len - i - 2);
 		vec_append_str(&printer->move, node->alias);
 		line = vec_get(&printer->lines, printer->start_line + i);
-		vec_append_str(line, printer->move.memory);
+		vec_append_strn(line, printer->move.memory, printer->move.len);
 		vec_append_strn(line, " ", 1);
 		i++;
 	}
@@ -108,14 +104,14 @@ static void	send_ant_wave(t_printer *printer, t_pathset *pathset)
 	printer->start_line++;
 }
 
-static void	put_line(void *line)
+static void	put_line(void *ptr)
 {
-	char	*str;
+	t_vec	*line;
 
-	str = ((t_vec *)line)->memory;
-	str[((t_vec *)line)->len - 1] = '\0';
+	line = (t_vec *)ptr;
+	((char *)line->memory)[line->len - 1] = '\n';
+	vec_append_strn(line, "\0", 1);
 	ft_putstr(((t_vec *)line)->memory);
-	ft_putchar('\n');
 }
 
 int	print_solution(t_flow_network *network, t_pathset *pathset)

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 18:47:54 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 14:32:35 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:41:01 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,11 +90,10 @@ static void	send_ant_wave(t_printer *printer, t_pathset *pathset)
 	printer->start_line++;
 }
 
-int	print_solution(t_flow_network *network, t_pathset *pathset)
+int	print_solution(t_pathset *pathset)
 {
 	t_printer	printer;
 
-	(void) network;
 	if (printer_init(&printer, pathset) == ERROR)
 		return (printer_free(&printer), ERROR);
 	while (has_ants_to_send(pathset))

--- a/src/print.c
+++ b/src/print.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 18:47:54 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 14:27:46 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:32:35 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,20 +51,6 @@ static void	printer_free(t_printer *printer)
 		vec_free(&printer->move);
 }
 
-static void	update_move_prefix(t_printer *printer)
-{
-	char	*number_string;
-
-	printer->move.len = 1;
-	number_string = ft_itoa(printer->ant_number);
-	if (!number_string)
-		return ;
-	vec_append_str(&printer->move, number_string);
-	ft_strdel(&number_string);
-	vec_append_strn(&printer->move, "-", 1);
-	printer->dash_id = printer->move.len;
-}
-
 static void	send_ant(t_printer *printer)
 {
 	t_flow_node	*node;
@@ -102,16 +88,6 @@ static void	send_ant_wave(t_printer *printer, t_pathset *pathset)
 		i++;
 	}
 	printer->start_line++;
-}
-
-static void	put_line(void *ptr)
-{
-	t_vec	*line;
-
-	line = (t_vec *)ptr;
-	((char *)line->memory)[line->len - 1] = '\n';
-	vec_append_strn(line, "\0", 1);
-	ft_putstr(((t_vec *)line)->memory);
 }
 
 int	print_solution(t_flow_network *network, t_pathset *pathset)

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 10:16:28 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 11:42:18 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 13:25:00 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,4 +20,3 @@ int	has_ants_to_send(t_pathset *pathset)
 		shortest_path = vec_get(&pathset->paths, 0);
 	return (shortest_path->ants > 0);
 }
-

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -1,30 +1,23 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   printer.h                                          :+:      :+:    :+:   */
+/*   print_utils.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2022/08/01 23:03:06 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 10:17:11 by carlnysten       ###   ########.fr       */
+/*   Created: 2022/08/02 10:16:28 by carlnysten        #+#    #+#             */
+/*   Updated: 2022/08/02 11:42:18 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef PRINTER_H
-# define PRINTER_H
+#include "lem_in.h"
 
-# include "lem_in.h"
-
-typedef struct s_printer
+int	has_ants_to_send(t_pathset *pathset)
 {
-	t_vec	lines;
-	t_path	*path;
-	t_vec	move;
-	int		ant_number;
-	size_t	start_line;
-}	t_printer;
+	static t_path	*shortest_path;
 
-int	print_solution(t_flow_network *network, t_pathset *pathset);
-int	has_ants_to_send(t_pathset *pathset);
+	if (!shortest_path)
+		shortest_path = vec_get(&pathset->paths, 0);
+	return (shortest_path->ants > 0);
+}
 
-#endif

--- a/src/print_utils.c
+++ b/src/print_utils.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 10:16:28 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 13:25:00 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:33:39 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,4 +19,28 @@ int	has_ants_to_send(t_pathset *pathset)
 	if (!shortest_path)
 		shortest_path = vec_get(&pathset->paths, 0);
 	return (shortest_path->ants > 0);
+}
+
+void	put_line(void *ptr)
+{
+	t_vec	*line;
+
+	line = (t_vec *)ptr;
+	((char *)line->memory)[line->len - 1] = '\n';
+	vec_append_strn(line, "\0", 1);
+	ft_putstr(((t_vec *)line)->memory);
+}
+
+void	update_move_prefix(t_printer *printer)
+{
+	char	*number_string;
+
+	printer->move.len = 1;
+	number_string = ft_itoa(printer->ant_number);
+	if (!number_string)
+		return ;
+	vec_append_str(&printer->move, number_string);
+	ft_strdel(&number_string);
+	vec_append_strn(&printer->move, "-", 1);
+	printer->dash_id = printer->move.len;
 }

--- a/tests/unit_tests/src/printer/test_print_solution.c
+++ b/tests/unit_tests/src/printer/test_print_solution.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   test_print.c                                       :+:      :+:    :+:   */
+/*   test_print_solution.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 22:24:15 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 11:46:51 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 13:23:41 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,9 +20,7 @@
  *     |/
  *     7
  */
-#include "lem_in.h"
 #include "unit_test.h"
-#include "vec.h"
 
 static void init_dummy_network(t_flow_network *network)
 {
@@ -48,17 +46,25 @@ static void init_dummy_network(t_flow_network *network)
 	network->sink = 7;
 }
 
-static void	init_dummy_pathset(t_pathset *pathset)
+static void	init_dummy_pathset(t_pathset *pathset, t_flow_network *network)
 {
 	t_path	path_a;
 	t_path	path_b;
-	size_t	nodes_a[] = {7, 5, 4, 1, 0};
-	size_t	nodes_b[] = {7, 6, 3, 2, 0};
 
 	path_a = (t_path){.ants = 3};
 	path_b = (t_path){.ants = 2};
-	assert(vec_from(&path_a.nodes, nodes_a, 5, sizeof (size_t)));
-	assert(vec_from(&path_b.nodes, nodes_b, 5, sizeof (size_t)));
+	assert(vec_new(&path_a.nodes, 1, sizeof (t_flow_node)) != ERROR);
+	assert(vec_new(&path_b.nodes, 1, sizeof (t_flow_node)) != ERROR);
+	assert(vec_push(&path_a.nodes, network_get(network, 7)) != ERROR);
+	assert(vec_push(&path_a.nodes, network_get(network, 5)) != ERROR);
+	assert(vec_push(&path_a.nodes, network_get(network, 4)) != ERROR);
+	assert(vec_push(&path_a.nodes, network_get(network, 1)) != ERROR);
+	assert(vec_push(&path_a.nodes, network_get(network, 0)) != ERROR);
+	assert(vec_push(&path_b.nodes, network_get(network, 7)) != ERROR);
+	assert(vec_push(&path_b.nodes, network_get(network, 6)) != ERROR);
+	assert(vec_push(&path_b.nodes, network_get(network, 3)) != ERROR);
+	assert(vec_push(&path_b.nodes, network_get(network, 2)) != ERROR);
+	assert(vec_push(&path_b.nodes, network_get(network, 0)) != ERROR);
 	*pathset = (t_pathset){.ants = 5, .steps = 6};
 	assert(vec_new(&pathset->paths, 2, sizeof (t_path)) != ERROR);
 	assert(vec_push(&pathset->paths, &path_a) != ERROR);
@@ -70,8 +76,8 @@ void	test_print_solution(void)
 	t_flow_network	network;
 	t_pathset		pathset;
 
-	init_dummy_pathset(&pathset);
 	init_dummy_network(&network);
+	init_dummy_pathset(&pathset, &network);
 	assert(print_solution(&network, &pathset) == OK);
 	network_free(&network);
 	pathset_free(&pathset);

--- a/tests/unit_tests/src/printer/test_print_solution.c
+++ b/tests/unit_tests/src/printer/test_print_solution.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 22:24:15 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 13:23:41 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 14:43:25 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ void	test_print_solution(void)
 
 	init_dummy_network(&network);
 	init_dummy_pathset(&pathset, &network);
-	assert(print_solution(&network, &pathset) == OK);
+	assert(print_solution(&pathset) == OK);
 	network_free(&network);
 	pathset_free(&pathset);
 }

--- a/tests/unit_tests/src/printer/test_print_solution.c
+++ b/tests/unit_tests/src/printer/test_print_solution.c
@@ -6,7 +6,7 @@
 /*   By: carlnysten <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 22:24:15 by carlnysten        #+#    #+#             */
-/*   Updated: 2022/08/02 10:12:52 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 11:46:51 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,8 +52,8 @@ static void	init_dummy_pathset(t_pathset *pathset)
 {
 	t_path	path_a;
 	t_path	path_b;
-	size_t	nodes_a[] = {0, 1, 4, 5, 7};
-	size_t	nodes_b[] = {0, 2, 3, 6, 7};
+	size_t	nodes_a[] = {7, 5, 4, 1, 0};
+	size_t	nodes_b[] = {7, 6, 3, 2, 0};
 
 	path_a = (t_path){.ants = 3};
 	path_b = (t_path){.ants = 2};
@@ -65,7 +65,7 @@ static void	init_dummy_pathset(t_pathset *pathset)
 	assert(vec_push(&pathset->paths, &path_b) != ERROR);
 }
 
-void	test_print(void)
+void	test_print_solution(void)
 {
 	t_flow_network	network;
 	t_pathset		pathset;

--- a/tests/unit_tests/src/printer/test_printer.c
+++ b/tests/unit_tests/src/printer/test_printer.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/09 13:08:46 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/01 22:24:00 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 11:49:34 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,5 +14,5 @@
 
 void	test_printer(void)
 {
-	test_print();
+	test_print_solution();
 }

--- a/tests/unit_tests/src/unit_test.h
+++ b/tests/unit_tests/src/unit_test.h
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/09 11:28:44 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/01 22:50:11 by carlnysten       ###   ########.fr       */
+/*   Updated: 2022/08/02 11:47:33 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,6 @@ void	test_bfs(void);
 void	test_bfs_search(void);
 
 void	test_printer(void);
-void	test_print(void);
+void	test_print_solution(void);
 
 #endif


### PR DESCRIPTION
Here is a basic implementation for options with a working quiet-flag for you to check out. This PR proposes these changes be merged into `solver_integration` (+ some printer changes that were previously unmerged).

`./lem-in -q` silences the parser and the printer. There is one exception to this, the parser comments. The generator always includes a comment saying how many steps were required, so printing those makes it easy to compare how our lem-in is performing. Using the -q flag also makes the program print the steps count of the best pathset found. See below.
<img width="659" alt="image" src="https://user-images.githubusercontent.com/65853349/182446322-6d8caa2f-eae6-459d-8e86-48938f1591e3.png">
