### PR TITLE
bugfix for pathset_trim

### DIFF
--- a/src/pathset_solve_tools.c
+++ b/src/pathset_solve_tools.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/02 16:40:55 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/03 14:04:48 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/03 17:02:11 by carlnysten       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,9 +53,9 @@ void	pathset_trim(t_pathset *pathset)
 	while (1)
 	{
 		quotient = (pathset->ants + pathset->total_nodes) / pathset->paths.len;
-		if (quotient > pathset_get(pathset, pathset->paths.len - 1)->height)
+		if (quotient >= pathset_get(pathset, pathset->paths.len - 1)->height)
 			break ;
-		while (quotient <= pathset_get(pathset, pathset->paths.len - 1)->height)
+		while (quotient < pathset_get(pathset, pathset->paths.len - 1)->height)
 		{
 			vec_pop(&path, &pathset->paths);
 			pathset->total_nodes -= path.height;


### PR DESCRIPTION
This fixes the bug on `flow-one-more-1' where a 3-path path set is chosen wrongly instead of a 4-path one. The error was a off-by-one type error in `pathset_trim`. See diff for the fix.