### PR TITLE
Shortcut finding optimisation

### DIFF
--- a/includes/flow.h
+++ b/includes/flow.h
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/28 14:13:21 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 10:12:49 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 16:04:44 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,6 +74,7 @@ typedef struct s_flow_node
 	size_t	dst_to_end;
 	uint8_t	is_free: 1;
 	uint8_t	is_via_augment: 1;
+	size_t	path_id;
 }				t_flow_node;
 
 /* ************************************************************************** */

--- a/includes/pathset.h
+++ b/includes/pathset.h
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 14:56:03 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 10:20:06 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/21 22:52:11 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,7 +85,6 @@ typedef struct s_pathset
 }				t_pathset;
 
 /* Pathset API */
-int			pathset_init(t_pathset *pathset, size_t n_paths, size_t n_ants);
 int			pathset_from_network(t_pathset *pathset, t_flow_network *network,
 				t_bfs_utils *bfs_utils);
 t_path		*pathset_get(t_pathset *pathset, size_t index);

--- a/maps/cases/augment_9.map
+++ b/maps/cases/augment_9.map
@@ -1,0 +1,34 @@
+100
+##start
+start 0 0
+##end
+end 1 1
+a 2 2
+b 3 3
+c 4 4
+d 5 5
+e 6 6
+f 7 7
+g 8 8
+h 9 9
+i 10 10
+j 16 16
+k 17 17
+l 18 18
+start-a
+a-b
+b-c
+c-end
+start-d
+d-e
+e-f
+f-b
+d-a
+f-a
+a-g
+g-h
+h-i
+i-j
+j-k
+k-l
+l-end

--- a/src/bfs.c
+++ b/src/bfs.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 18:33:35 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 11:14:42 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 16:09:42 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,7 @@ int	bfs_reset(t_bfs_utils *bfs_utils, t_flow_network *network)
 	bfs_utils->queue.head = 0;
 	bfs_utils->queue.tail = 0;
 	bfs_utils->trace.sink_edges.len = 0;
+	network_get(network, network->source)->path_id = network->source;
 	if (queue_push(&bfs_utils->queue, &network->source) == ERROR)
 		return (ERROR);
 	return ((bfs_utils->marked)[network->source] = 1, OK);

--- a/src/bfs.c
+++ b/src/bfs.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 18:33:35 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/19 16:09:42 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/22 12:25:40 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,14 @@ int	bfs_init(t_bfs_utils *bfs_utils, t_flow_network *network, int saturate)
 	return ((bfs_utils->marked)[*source] = 1, OK);
 }
 
+static void bfs_reset_dst_to_start(t_flow_network *network)
+{
+	size_t	index;
+
+	index = 0;
+	while (index < network->adj_list.len)
+		network_get(network, index++)->dst_to_start = 0;
+}
 /* Resets BFS utilities (assigning 0) for next BFS iteration */
 int	bfs_reset(t_bfs_utils *bfs_utils, t_flow_network *network)
 {
@@ -45,6 +53,7 @@ int	bfs_reset(t_bfs_utils *bfs_utils, t_flow_network *network)
 	bfs_utils->queue.tail = 0;
 	bfs_utils->trace.sink_edges.len = 0;
 	network_get(network, network->source)->path_id = network->source;
+	bfs_reset_dst_to_start(network);
 	if (queue_push(&bfs_utils->queue, &network->source) == ERROR)
 		return (ERROR);
 	return ((bfs_utils->marked)[network->source] = 1, OK);

--- a/src/bfs_search.c
+++ b/src/bfs_search.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 19:50:43 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/19 11:56:50 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 16:19:53 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,11 +25,13 @@ static int	save_edge(t_flow_network *network, t_bfs_utils *bfs_utils,
 		size_t to, t_flow_edge *edge)
 {
 	t_flow_node	*from;
+	t_flow_node	*dst;
 
 	from = network_get(network, edge_other(edge, to));
+	dst = network_get(network, to);
 	if (!bfs_utils->marked[to] && !bfs_utils->saturate_trace)
-		network_get(network, to)->dst_to_start
-		= from->dst_to_start + (!edge->flow);
+		dst->dst_to_start = from->dst_to_start + (!edge->flow);
+	dst->path_id = from->path_id * dst->is_free + dst->path_id * !dst->is_free;
 	(bfs_utils->trace.edge_to)[to] = edge;
 	bfs_utils->marked[to] = TRUE;
 	if (to != network->sink)
@@ -51,8 +53,10 @@ static int	is_valid_neighbour(size_t to, t_flow_edge edge,
 	dst = network_get(&network, to);
 	origin = network_get(&network, edge_other(&edge, to));
 	is_backtrack = (edge.flow && edge.from == to && to != network.source);
-	is_overwrite = (!edge.flow && dst->dst_to_start == origin->dst_to_start + 1);
-	return (!bfs_utils.marked[to] || is_backtrack || is_overwrite || to == network.sink);
+	is_overwrite = (!edge.flow && dst->dst_to_start == origin->dst_to_start + 1
+			&& dst->path_id == origin->path_id);
+	return (!bfs_utils.marked[to] || is_backtrack
+		|| is_overwrite || to == network.sink);
 }
 
 /* Loops through each edge in a node's edge bag 

--- a/src/bfs_search.c
+++ b/src/bfs_search.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 19:50:43 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/19 16:19:53 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 17:02:01 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,13 +45,8 @@ static int	save_edge(t_flow_network *network, t_bfs_utils *bfs_utils,
 static int	is_valid_neighbour(size_t to, t_flow_edge edge,
 		t_bfs_utils bfs_utils, t_flow_network network)
 {
-	int			is_backtrack;
-	int			is_overwrite;
-	t_flow_node	*dst;
-	t_flow_node	*origin;
+	int	is_backtrack;
 
-	dst = network_get(&network, to);
-	origin = network_get(&network, edge_other(&edge, to));
 	is_backtrack = (edge.flow && edge.from == to && to != network.source);
 	is_overwrite = (!edge.flow && dst->dst_to_start == origin->dst_to_start + 1
 			&& dst->path_id == origin->path_id);

--- a/src/bfs_search.c
+++ b/src/bfs_search.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 19:50:43 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 11:50:39 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 11:56:50 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,10 +43,16 @@ static int	save_edge(t_flow_network *network, t_bfs_utils *bfs_utils,
 static int	is_valid_neighbour(size_t to, t_flow_edge edge,
 		t_bfs_utils bfs_utils, t_flow_network network)
 {
-	int	is_backtrack;
+	int			is_backtrack;
+	int			is_overwrite;
+	t_flow_node	*dst;
+	t_flow_node	*origin;
 
+	dst = network_get(&network, to);
+	origin = network_get(&network, edge_other(&edge, to));
 	is_backtrack = (edge.flow && edge.from == to && to != network.source);
-	return (!bfs_utils.marked[to] || is_backtrack || to == network.sink);
+	is_overwrite = (!edge.flow && dst->dst_to_start == origin->dst_to_start + 1);
+	return (!bfs_utils.marked[to] || is_backtrack || is_overwrite || to == network.sink);
 }
 
 /* Loops through each edge in a node's edge bag 

--- a/src/bfs_search.c
+++ b/src/bfs_search.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/27 19:50:43 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/21 22:12:34 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/21 22:36:07 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,9 +33,6 @@ static void	memoize_search_history(size_t to, t_flow_edge *edge,
  * Updates edge_to array and marks to node as visited.
  * Memoizes bfs traversal history in visited node.
  * Enqueues node if it is not the end node.
- * Search ends if the node is the SINK && saturate_trace == FALSE
- * If saturate_trace == TRUE, search continues until sink_edges is
- * saturated.
 */
 static int	save_edge(t_flow_network *network, t_bfs_utils *bfs_utils,
 		size_t to, t_flow_edge *edge)
@@ -51,6 +48,7 @@ static int	save_edge(t_flow_network *network, t_bfs_utils *bfs_utils,
 		SEARCH_CONTINUE);
 }
 
+/* Valid neighbour: unvisited, is backtracking, is shortcut, sink node */
 static int	is_valid_neighbour(size_t to, t_flow_edge edge,
 		t_bfs_utils bfs_utils, t_flow_network network)
 {
@@ -70,10 +68,7 @@ static int	is_valid_neighbour(size_t to, t_flow_edge edge,
 		|| to == network.sink);
 }
 
-/* Loops through each edge in a node's edge bag 
- * Is the node on the other end of the edge is a valid neighbour, and 
- * satisfies a given "condition", then the node is enqueued and the edge
- * is saved to the trace */
+/* Pops next node off the queue, and tests its edges against given condition */
 static int	scan_next_node(t_flow_network *network, t_bfs_utils *bfs_utils,
 		int (*condition)(t_flow_edge *, const size_t, t_vec *))
 {
@@ -108,7 +103,7 @@ static int	scan_next_node(t_flow_network *network, t_bfs_utils *bfs_utils,
  *
  * Incrementally pops nodes off the queue, and scan's the node's respective
  * edges. Nodes that satisfy a given condition are enqueued, and the
- * corresponding edge is saved to the trace.
+ * corresponding edge is saved to the edge_to & sink_edges trace.
  */
 int	bfs_search(t_flow_network *network, t_bfs_utils *bfs_utils,
 		int (*condition)(t_flow_edge *, const size_t, t_vec *))

--- a/src/flow_network_augment.c
+++ b/src/flow_network_augment.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 14:26:15 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/21 22:41:48 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/22 12:27:09 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,9 @@ int	network_has_augmenting_path(t_flow_network *network, t_bfs_utils *bfs_utils)
  * */
 static void	switch_edge(size_t res, t_trace trace, t_flow_network *network)
 {
-	t_flow_edge	*edge;
 	size_t		index;
+	size_t		target_index;
+	t_flow_edge	*edge;
 	t_flow_node	*node;
 	t_flow_node	*target_node;
 
@@ -40,8 +41,10 @@ static void	switch_edge(size_t res, t_trace trace, t_flow_network *network)
 	while (index < node->edges.len)
 	{
 		edge = node_get(node, index++);
-		target_node = network_get(network, edge_other(edge, res));
-		if (!edge->flow && target_node->dst_to_start == node->dst_to_start - 1)
+		target_index = edge_other(edge, res);
+		target_node = network_get(network, target_index);
+		if (!edge->flow && trace.edge_to[target_index]
+			&& target_node->dst_to_start == node->dst_to_start - 1)
 		{
 			trace.edge_to[res] = edge;
 			return ;

--- a/src/flow_network_augment.c
+++ b/src/flow_network_augment.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 14:26:15 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 17:59:51 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/21 22:41:48 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,7 @@
 
 /* Uses BFS to determined whether the network has an augmentable path 
  * Returns TRUE or FALSE
- * bfs_search will save edge_to trace in bfs_utils
- * */
+ */
 int	network_has_augmenting_path(t_flow_network *network, t_bfs_utils *bfs_utils)
 {
 	bfs_utils->saturate_trace = FALSE;
@@ -23,10 +22,7 @@ int	network_has_augmenting_path(t_flow_network *network, t_bfs_utils *bfs_utils)
 }
 
 /* The selected best exit node from select_best_exit is scanned for the 
- * appropriate corresponding target node to exit to.
- * The appropriate target node should:
- * Have NO flow
- * Has a dst_to_start = exit node's dst_to_start - 1
+ * appropriate exit node.
  * */
 static void	switch_edge(size_t res, t_trace trace, t_flow_network *network)
 {
@@ -54,8 +50,8 @@ static void	switch_edge(size_t res, t_trace trace, t_flow_network *network)
 }
 
 /* When network_augment encounters a node on a path, determines the best
- * exit node from the path. The best exit node is the one that results in 
- * the shortest augmented path */
+ * augmentable node from the path. The best node is the one with minimum
+ * dst_to_start + dst_to_end. A connection to start node is guaranteed.*/
 static void	select_best_exit(t_flow_network *network, size_t index,
 	t_trace trace)
 {

--- a/src/flow_node.c
+++ b/src/flow_node.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/07 16:04:24 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 11:04:20 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/22 14:05:28 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ int	node_make(t_flow_node *node, char *alias, int x, int y)
 	node->is_via_augment = 0;
 	node->dst_to_start = 0;
 	node->dst_to_end = 0;
+	node->path_id = 0;
 	return (vec_new(&(node->edges), 1, sizeof(t_flow_edge *)));
 }
 

--- a/src/path.c
+++ b/src/path.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 16:00:39 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 11:09:06 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/19 16:20:45 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ int	path_fill(t_path *path, size_t index, t_trace trace,
 {
 	t_flow_edge	*edge;
 	t_flow_node	*node;
+	t_flow_node	*from;
 	size_t		dst_to_end;
 
 	if (!path || !trace.edge_to || !trace.sink_edges.memory)
@@ -39,6 +40,9 @@ int	path_fill(t_path *path, size_t index, t_trace trace,
 	{
 		node = network_get(network, edge->to);
 		node->dst_to_end = dst_to_end++;
+		from = network_get(network, edge->from);
+		from->path_id = edge->from * (edge->to == network->sink)
+			+ node->path_id * (edge->to != network->sink);
 		if (vec_push(&path->nodes, &node) == ERROR)
 			return (ERROR);
 		edge = trace.edge_to[edge->from];

--- a/src/path.c
+++ b/src/path.c
@@ -6,7 +6,7 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 16:00:39 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/19 16:20:45 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/21 22:48:37 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,8 @@ int	path_new(t_path *path)
 	return (OK);
 }
 
-/* Fills path with nodes found in the edge_to trace. Simultaneously computes
- * the node's corresonding dst_to_end node */
+/* Fills path with nodes found in the edge_to trace. Updates the node's
+ * corresonding dst_to_end */
 int	path_fill(t_path *path, size_t index, t_trace trace,
 		t_flow_network *network)
 {
@@ -39,8 +39,8 @@ int	path_fill(t_path *path, size_t index, t_trace trace,
 	while (edge)
 	{
 		node = network_get(network, edge->to);
-		node->dst_to_end = dst_to_end++;
 		from = network_get(network, edge->from);
+		node->dst_to_end = dst_to_end++;
 		from->path_id = edge->from * (edge->to == network->sink)
 			+ node->path_id * (edge->to != network->sink);
 		if (vec_push(&path->nodes, &node) == ERROR)

--- a/src/pathset.c
+++ b/src/pathset.c
@@ -6,14 +6,14 @@
 /*   By: cchen <cchen@student.hive.fi>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/01 15:12:34 by cchen             #+#    #+#             */
-/*   Updated: 2022/08/18 11:10:44 by cchen            ###   ########.fr       */
+/*   Updated: 2022/08/21 22:52:04 by cchen            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lem_in.h"
 
 /* Allocates memory for, and creates a new pathset */
-int	pathset_init(t_pathset *pathset, size_t n_paths, size_t n_ants)
+static int	pathset_init(t_pathset *pathset, size_t n_paths, size_t n_ants)
 {
 	t_path	path;
 


### PR DESCRIPTION
Further optimisation to the dynamic programming in bfs search.

The bfs search is allowed to revisit some visited, and free nodes (free being not on an existing path), if it considers it a shortcut.

Bfs determines the next node will be a shortcut IF:
- The next node was previously visited through a trail extending from the same path, as the current node.
- the next node's dst_to_start is the current node's dst_to_Start + 1
- the next node was visited through a trail closer to the end node than the current node's trail.