### PR TITLE
error script added

### DIFF
--- a/tests/error/errors.sh
+++ b/tests/error/errors.sh
@@ -1,0 +1,11 @@
+#!/bin/zsh
+
+DIR=$(dirname `which $0`)
+cd $DIR
+
+echo "Testing all error maps..."
+for f in $(find ../../maps/error -type f -name "*"); do
+	echo ''
+	echo $f | cut -d'/' -f 3,4,5
+	../../lem-in < $f
+done;


### PR DESCRIPTION
Here's a super simple error script. It just runs Lem-in on all error maps.

I made this so we can more easily check our error handling. At the moment it looks like we sometimes print out double error messages. I don't know if this is an issue but we might want to change it so only one msg is printed. That could be the next thing to change.